### PR TITLE
decoupling editor/MapEditor from editor/OperationStack

### DIFF
--- a/core/src/io/anuke/mindustry/editor/DrawOperation.java
+++ b/core/src/io/anuke/mindustry/editor/DrawOperation.java
@@ -12,7 +12,12 @@ import static io.anuke.mindustry.Vars.content;
 import static io.anuke.mindustry.Vars.world;
 
 public class DrawOperation{
+    private MapEditor editor;
     private LongArray array = new LongArray();
+
+    public DrawOperation(MapEditor editor) {
+        this.editor = editor;
+    }
 
     public boolean isEmpty(){
         return array.isEmpty();
@@ -22,22 +27,22 @@ public class DrawOperation{
         array.add(op);
     }
 
-    public void undo(MapEditor editor){
+    public void undo(){
         for(int i = array.size - 1; i >= 0; i--){
-            updateTile(editor, i);
+            updateTile(i);
         }
     }
 
-    public void redo(MapEditor editor){
+    public void redo(){
         for(int i = 0; i < array.size; i++){
-            updateTile(editor, i);
+            updateTile(i);
         }
     }
 
-    private void updateTile(MapEditor editor, int i) {
+    private void updateTile(int i) {
         long l = array.get(i);
         array.set(i, TileOp.get(TileOp.x(l), TileOp.y(l), TileOp.type(l), getTile(editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l))));
-        setTile(editor, editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l), TileOp.value(l));
+        setTile(editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l), TileOp.value(l));
     }
 
     short getTile(Tile tile, byte type){
@@ -55,7 +60,7 @@ public class DrawOperation{
         throw new IllegalArgumentException("Invalid type.");
     }
 
-    void setTile(MapEditor editor, Tile tile, byte type, short to){
+    void setTile(Tile tile, byte type, short to){
         editor.load(() -> {
             if(type == OpType.floor.ordinal()){
                 tile.setFloor((Floor)content.block(to));

--- a/core/src/io/anuke/mindustry/editor/MapEditor.java
+++ b/core/src/io/anuke/mindustry/editor/MapEditor.java
@@ -240,13 +240,13 @@ public class MapEditor{
 
     public void undo(){
         if(stack.canUndo()){
-            stack.undo(this);
+            stack.undo();
         }
     }
 
     public void redo(){
         if(stack.canRedo()){
-            stack.redo(this);
+            stack.redo();
         }
     }
 
@@ -267,7 +267,7 @@ public class MapEditor{
     public void addTileOp(long data){
         if(loading) return;
 
-        if(currentOp == null) currentOp = new DrawOperation();
+        if(currentOp == null) currentOp = new DrawOperation(this);
         currentOp.addOperation(data);
 
         renderer.updatePoint(TileOp.x(data), TileOp.y(data));

--- a/core/src/io/anuke/mindustry/editor/OperationStack.java
+++ b/core/src/io/anuke/mindustry/editor/OperationStack.java
@@ -34,18 +34,18 @@ public class OperationStack{
         return !(index > -1 || stack.size + index < 0);
     }
 
-    public void undo(MapEditor editor){
+    public void undo(){
         if(!canUndo()) return;
 
-        stack.get(stack.size - 1 + index).undo(editor);
+        stack.get(stack.size - 1 + index).undo();
         index--;
     }
 
-    public void redo(MapEditor editor){
+    public void redo(){
         if(!canRedo()) return;
 
         index++;
-        stack.get(stack.size - 1 + index).redo(editor);
+        stack.get(stack.size - 1 + index).redo();
 
     }
 }


### PR DESCRIPTION
## Abstract
Decouple [MapEditor](https://github.com/Anuken/Mindustry/blob/master/core/src/io/anuke/mindustry/editor/MapEditor.java) from [OperationStack](https://github.com/Anuken/Mindustry/blob/master/core/src/io/anuke/mindustry/editor/OperationStack.java). [OperationStack](https://github.com/Anuken/Mindustry/blob/master/core/src/io/anuke/mindustry/editor/OperationStack.java) does not know about the [`MapEditor`](https://github.com/Anuken/Mindustry/blob/master/core/src/io/anuke/mindustry/editor/MapEditor.java) now.

## Changed
- extract [`MapEditor`](https://github.com/Anuken/Mindustry/blob/master/core/src/io/anuke/mindustry/editor/MapEditor.java) from [`editor/OperationStack`](https://github.com/Anuken/Mindustry/blob/master/core/src/io/anuke/mindustry/editor/OperationStack.java)
- [`DrawOperation`](https://github.com/Anuken/Mindustry/blob/master/core/src/io/anuke/mindustry/editor/DrawOperation.java) has [MapEditor](https://github.com/Anuken/Mindustry/blob/master/core/src/io/anuke/mindustry/editor/MapEditor.java) field which is assigned on initialization.
