### PR TITLE
Editor design pattern

### DIFF
--- a/core/src/io/anuke/mindustry/editor/DrawOperation.java
+++ b/core/src/io/anuke/mindustry/editor/DrawOperation.java
@@ -11,7 +11,7 @@ import io.anuke.mindustry.world.blocks.Floor;
 import static io.anuke.mindustry.Vars.content;
 import static io.anuke.mindustry.Vars.world;
 
-public class DrawOperation{
+public class DrawOperation implements Rollbackable{
     private MapEditor editor;
     private LongArray array = new LongArray();
 

--- a/core/src/io/anuke/mindustry/editor/DrawOperation.java
+++ b/core/src/io/anuke/mindustry/editor/DrawOperation.java
@@ -41,7 +41,8 @@ public class DrawOperation{
 
     private void updateTile(int i) {
         long l = array.get(i);
-        array.set(i, TileOp.get(TileOp.x(l), TileOp.y(l), TileOp.type(l), getTile(editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l))));
+        short tile = getTile(editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l));
+        array.set(i, TileOp.get(TileOp.x(l), TileOp.y(l), TileOp.type(l), tile));
         setTile(editor.tile(TileOp.x(l), TileOp.y(l)), TileOp.type(l), TileOp.value(l));
     }
 

--- a/core/src/io/anuke/mindustry/editor/MapEditor.java
+++ b/core/src/io/anuke/mindustry/editor/MapEditor.java
@@ -240,13 +240,15 @@ public class MapEditor{
 
     public void undo(){
         if(stack.canUndo()){
-            stack.undo();
+            DrawOperation currentOp = stack.undo();
+            currentOp.undo();
         }
     }
 
     public void redo(){
         if(stack.canRedo()){
-            stack.redo();
+            DrawOperation currentOp = stack.redo();
+            currentOp.redo();
         }
     }
 

--- a/core/src/io/anuke/mindustry/editor/MapEditor.java
+++ b/core/src/io/anuke/mindustry/editor/MapEditor.java
@@ -240,14 +240,14 @@ public class MapEditor{
 
     public void undo(){
         if(stack.canUndo()){
-            DrawOperation currentOp = stack.undo();
+            Rollbackable currentOp = stack.undo();
             currentOp.undo();
         }
     }
 
     public void redo(){
         if(stack.canRedo()){
-            DrawOperation currentOp = stack.redo();
+            Rollbackable currentOp = stack.redo();
             currentOp.redo();
         }
     }

--- a/core/src/io/anuke/mindustry/editor/OperationStack.java
+++ b/core/src/io/anuke/mindustry/editor/OperationStack.java
@@ -4,7 +4,7 @@ import io.anuke.arc.collection.Array;
 
 public class OperationStack{
     private final static int maxSize = 10;
-    private Array<DrawOperation> stack = new Array<>();
+    private Array<Rollbackable> stack = new Array<>();
     private int index = 0;
 
     public OperationStack(){
@@ -16,7 +16,7 @@ public class OperationStack{
         index = 0;
     }
 
-    public void add(DrawOperation action){
+    public void add(Rollbackable action){
         stack.truncate(stack.size + index);
         index = 0;
         stack.add(action);
@@ -34,14 +34,14 @@ public class OperationStack{
         return !(index > -1 || stack.size + index < 0);
     }
 
-    public DrawOperation undo(){
+    public Rollbackable undo(){
         if(!canUndo()) return null;
 
         index--;
         return stack.get(stack.size + index);//.undo();
     }
 
-    public DrawOperation redo(){
+    public Rollbackable redo(){
         if(!canRedo()) return null;
 
         index++;

--- a/core/src/io/anuke/mindustry/editor/OperationStack.java
+++ b/core/src/io/anuke/mindustry/editor/OperationStack.java
@@ -34,18 +34,17 @@ public class OperationStack{
         return !(index > -1 || stack.size + index < 0);
     }
 
-    public void undo(){
-        if(!canUndo()) return;
+    public DrawOperation undo(){
+        if(!canUndo()) return null;
 
-        stack.get(stack.size - 1 + index).undo();
         index--;
+        return stack.get(stack.size + index);//.undo();
     }
 
-    public void redo(){
-        if(!canRedo()) return;
+    public DrawOperation redo(){
+        if(!canRedo()) return null;
 
         index++;
-        stack.get(stack.size - 1 + index).redo();
-
+        return stack.get(stack.size + index);//.redo();
     }
 }

--- a/core/src/io/anuke/mindustry/editor/Rollbackable.java
+++ b/core/src/io/anuke/mindustry/editor/Rollbackable.java
@@ -1,0 +1,6 @@
+package io.anuke.mindustry.editor;
+
+public interface Rollbackable {
+    void undo();
+    void redo();
+}


### PR DESCRIPTION
## 요약
[Strategy pattern](https://refactoring.guru/design-patterns/strategy)을 사용하여 `OperationStack`, `DrawOperation`을 분리

## 설명
- `OperationStack`에서 이제 `DrawOperation` 대신 `Rollbackable` 인터페이스로 접근
- `OperationStack`은 이제 `DrawOperation` 말고도 `undo`, `redo`의 기능을 가지고 있는 다른 요소를 관리할 수 있음

## 클래스 다이어그램
| before | after |
| --- | --- |
| ![OperationStack_before](https://user-images.githubusercontent.com/37643248/59138398-cbab2900-89c7-11e9-9fec-afcef58b74bd.png) | ![OperationStack_after](https://user-images.githubusercontent.com/37643248/59138448-25135800-89c8-11e9-926f-6fa74de95763.png) |

