### PR TITLE
Apply design pattern to `render` method in `MapRenderer.java`

### DIFF
--- a/core/src/io/anuke/mindustry/editor/MapRenderer.java
+++ b/core/src/io/anuke/mindustry/editor/MapRenderer.java
@@ -3,22 +3,10 @@ package io.anuke.mindustry.editor;
 import io.anuke.arc.Core;
 import io.anuke.arc.collection.IntSet;
 import io.anuke.arc.collection.IntSet.IntSetIterator;
-import io.anuke.arc.graphics.Color;
 import io.anuke.arc.graphics.Texture;
 import io.anuke.arc.graphics.g2d.Draw;
-import io.anuke.arc.graphics.g2d.TextureAtlas.AtlasRegion;
-import io.anuke.arc.graphics.g2d.TextureRegion;
-import io.anuke.arc.math.Mathf;
 import io.anuke.arc.util.Disposable;
-import io.anuke.mindustry.content.Blocks;
-import io.anuke.mindustry.game.Team;
 import io.anuke.mindustry.graphics.IndexedRenderer;
-import io.anuke.mindustry.world.Block;
-import io.anuke.mindustry.world.Tile;
-import io.anuke.mindustry.world.blocks.BlockPart;
-import java.awt.Point;
-import java.awt.geom.Rectangle2D;
-import java.awt.geom.Rectangle2D.Float;
 
 import static io.anuke.mindustry.Vars.tilesize;
 
@@ -101,89 +89,10 @@ public class MapRenderer implements Disposable{
     }
 
     private void render(int wx, int wy){
-        final Point windowPoint = new Point(wx, wy);
-        final Point gridPoint = new Point(wx/chunkSize, wy/chunkSize);
-
-        final Point chunkStartPoint = getChunkStartPoint(windowPoint);
-        final int chunkArea = chunkSize * chunkSize;
-
-
-        IndexedRenderer mesh = getMesh(gridPoint);
-        Tile tile = getTile(windowPoint);
-        Block wall = tile.block();
-
-        int indexWall = chunkStartPoint.x + chunkStartPoint.y;
-        int indexDecal = chunkStartPoint.x  + chunkStartPoint.y + chunkArea;
-
-        renderMeshRegion(windowPoint, mesh, tile, wall, indexWall);
-
-
-        renderTileRegion(windowPoint, mesh, tile, wall, indexWall, indexDecal);
-    }
-
-    private void renderTileRegion(Point windowPoint, IndexedRenderer mesh, Tile tile, Block wall, int indexWall, int indexDecal) {
-        TextureRegion textureRegion;
-        final boolean isEditorIconExist = Core.atlas.isFound(wall.editorIcon());
-
-        Float tileRegion = new Float();
-        Team team = tile.getTeam();
-        float offsetSize = -Mathf.floor((float)(wall.size / 3.0)) * tilesize;
-        FloatPoint offset = new FloatPoint(offsetSize, offsetSize);
-
-        final boolean isTeamDrawRequired = wall.update || wall.destructible;
-        if(isTeamDrawRequired){
-            mesh.setColor(team.color);
-            textureRegion = getRegionInstance("block-border-editor");
-        }else if(!wall.synthetic() && !isAirBlock(wall)){
-            textureRegion = getEditorIcon(wall, isEditorIconExist);
-            offset.x = getMeshOffset(textureRegion.getWidth());
-            offset.y = getMeshOffset(textureRegion.getHeight());
-        }else if(isAirBlock(wall) && tile.overlay() != null){
-            int random = getRandomValue(indexWall, tile.overlay().editorVariantRegions().length);
-            textureRegion = tile.overlay().editorVariantRegions()[random];
-        }else{
-            textureRegion = getRegionInstance("clear-editor");
-        }
-
-        tileRegion.x = windowPoint.x * tilesize + offset.x;
-        tileRegion.y = windowPoint.y * tilesize + offset.y;
-        tileRegion.width = textureRegion.getWidth() * Draw.scl;
-        tileRegion.height = textureRegion.getHeight() * Draw.scl;
-
-        drawMesh(mesh, tile, textureRegion, indexDecal, tileRegion, false);
-        mesh.setColor(Color.WHITE);
-    }
-
-
-    private void renderMeshRegion(Point windowPoint, IndexedRenderer mesh, Tile tile, Block wall, int indexWall) {
-        TextureRegion textureRegion;
-        final boolean isBlockPart = (wall.synthetic() || wall instanceof BlockPart);
-        final boolean isEditorIconExist = Core.atlas.isFound(wall.editorIcon());
-
-        Float meshRegion = new Float();
-        boolean needsRotate = false;
-        Block floor = tile.floor();
-
-        meshRegion.x = windowPoint.x * tilesize;
-        meshRegion.y = windowPoint.y * tilesize;
-        if(!isAirBlock(wall) && isBlockPart){
-            textureRegion = getEditorIcon(wall, isEditorIconExist);
-            needsRotate = wall.rotate;
-            meshRegion.x += wall.offset();
-            meshRegion.y += wall.offset();
-            if (!needsRotate) {
-              meshRegion.x += getMeshOffset(textureRegion.getWidth());
-              meshRegion.y += getMeshOffset(textureRegion.getHeight());
-            }
-            meshRegion.width = textureRegion.getWidth() * Draw.scl;
-            meshRegion.height = textureRegion.getHeight() * Draw.scl;
-        }else{
-            int random = getRandomValue(indexWall, floor.editorVariantRegions().length);
-            textureRegion = floor.editorVariantRegions()[random];
-            meshRegion.width = tilesize;
-            meshRegion.height = tilesize;
-        }
-        drawMesh(mesh, tile, textureRegion, indexWall, meshRegion, needsRotate);
+        RenderStrategy meshRendering = MeshStrategy.getInstance(editor, chunks, wx, wy, chunkSize);
+        RenderStrategy tileRendering = TileStrategy.getInstance(editor, chunks, wx, wy, chunkSize);
+        meshRendering.renderRegion();
+        tileRendering.renderRegion();
     }
 
     @Override
@@ -197,68 +106,6 @@ public class MapRenderer implements Disposable{
                     chunks[x][y].dispose();
                 }
             }
-        }
-    }
-
-    private void drawMesh(IndexedRenderer mesh, Tile tile, TextureRegion textureRegion,
-        int index, Rectangle2D.Float meshRegion, boolean needsRotate) {
-        if(needsRotate){
-            final float rotationDegree = tile.rotation() * 90 - 90;
-            mesh.draw(index, textureRegion,
-                      meshRegion.x,
-                      meshRegion.y,
-                      meshRegion.width,
-                      meshRegion.height,
-                      rotationDegree);
-        }else{
-            mesh.draw(index, textureRegion,
-                      meshRegion.x,
-                      meshRegion.y,
-                      meshRegion.width,
-                      meshRegion.height);
-        }
-    }
-
-    private int getRandomValue(int index, int length) {
-        return Mathf.randomSeed(index, 0, length - 1);
-    }
-
-    private Tile getTile(Point point){
-        return editor.tiles()[point.x][point.y];
-    }
-
-    private IndexedRenderer getMesh(Point point) {
-        return chunks[point.x][point.y];
-    }
-
-    private Point getChunkStartPoint(Point point) {
-        int startX = (point.x % chunkSize);
-        int startY = (point.y % chunkSize) * chunkSize;
-        return new Point(startX, startY);
-    }
-
-    private boolean isAirBlock(Block block) {
-        return block.equals(Blocks.air);
-    }
-
-    private AtlasRegion getRegionInstance(String name) {
-        return Core.atlas.find(name);
-    }
-
-    private float getMeshOffset(float size) {
-        return (tilesize - size * Draw.scl) / 2f;
-    }
-
-    private TextureRegion getEditorIcon(Block wall, boolean isEditorIconExist) {
-        return isEditorIconExist ? wall.editorIcon() : getRegionInstance("clear-editor");
-    }
-
-    private class FloatPoint{
-        private float x;
-        private float y;
-        private FloatPoint(float x, float y) {
-            this.x = x;
-            this.y = y;
         }
     }
 }

--- a/core/src/io/anuke/mindustry/editor/MeshStrategy.java
+++ b/core/src/io/anuke/mindustry/editor/MeshStrategy.java
@@ -1,0 +1,68 @@
+package io.anuke.mindustry.editor;
+
+import io.anuke.arc.Core;
+import io.anuke.arc.graphics.g2d.Draw;
+import io.anuke.arc.graphics.g2d.TextureRegion;
+import io.anuke.arc.math.geom.Point2;
+import io.anuke.mindustry.graphics.IndexedRenderer;
+import io.anuke.mindustry.world.blocks.BlockPart;
+
+public class MeshStrategy extends RenderStrategy{
+    private static MeshStrategy meshStrategy;
+    private int indexWall;
+
+    private MeshStrategy() {
+        super();
+        indexWall = 0;
+    }
+
+    public static MeshStrategy getInstance(MapEditor editor, IndexedRenderer[][] chunks,
+                                                        int windowX, int windowY, int chunkSize){
+        if (meshStrategy == null) {
+            meshStrategy = new MeshStrategy();
+        }
+        preprocessing(meshStrategy, editor, chunks, windowX, windowY, chunkSize);
+        Point2 chunkStart = meshStrategy.getChunkStartPoint();
+        final int indexWall = chunkStart.x + chunkStart.y;
+        meshStrategy.setIndexWall(indexWall);
+        return meshStrategy;
+    }
+
+    @Override
+    public void renderRegion() {
+        TextureRegion textureRegion;
+        final boolean isAirBlock = getIsAirBlock(wall);
+        final boolean isBlockPart = (wall.synthetic() || wall instanceof BlockPart);
+        boolean needsRotate = false;
+
+        region.setX(windowPoint.x * tileSize);
+        region.setY(windowPoint.y * tileSize);
+        region.setWidth(tileSize);
+        region.setHeight(tileSize);
+        if (!isAirBlock && isBlockPart) {
+            final boolean isEditorIconExist = Core.atlas.isFound(wall.editorIcon());
+            float offsetX = wall.offset();
+            float offsetY = wall.offset();
+            needsRotate = wall.rotate;
+            textureRegion = getEditorIcon(wall, isEditorIconExist);
+
+            if (!needsRotate) {
+                offsetX += getMeshOffset(textureRegion.getWidth());
+                offsetY += getMeshOffset(textureRegion.getHeight());
+            }
+            region.setX(region.getX() + offsetX);
+            region.setY(region.getY() + offsetY);
+            region.setWidth(textureRegion.getWidth() * Draw.scl);
+            region.setHeight(textureRegion.getHeight() * Draw.scl);
+        } else {
+            final int editorVariantRegionLength = tile.floor().editorVariantRegions().length;
+            final int randomValue = getRandomValue(indexWall, editorVariantRegionLength);
+            textureRegion = tile.floor().editorVariantRegions()[randomValue];
+        }
+        drawMesh(textureRegion, indexWall, needsRotate);
+    }
+
+    public void setIndexWall(int indexWall) {
+        this.indexWall = indexWall;
+    }
+}

--- a/core/src/io/anuke/mindustry/editor/RenderStrategy.java
+++ b/core/src/io/anuke/mindustry/editor/RenderStrategy.java
@@ -1,0 +1,203 @@
+package io.anuke.mindustry.editor;
+
+import io.anuke.arc.Core;
+import io.anuke.arc.graphics.g2d.Draw;
+import io.anuke.arc.graphics.g2d.TextureAtlas;
+import io.anuke.arc.graphics.g2d.TextureRegion;
+import io.anuke.arc.math.Mathf;
+import io.anuke.arc.math.geom.Point2;
+import io.anuke.arc.math.geom.Rectangle;
+import io.anuke.mindustry.content.Blocks;
+import io.anuke.mindustry.graphics.IndexedRenderer;
+import io.anuke.mindustry.world.Block;
+import io.anuke.mindustry.world.Tile;
+
+import static io.anuke.mindustry.Vars.tilesize;
+
+public abstract class RenderStrategy {
+    protected Point2 windowPoint;
+    protected Point2 gridPoint;
+    protected Point2 chunkStartPoint;
+
+    protected FloatPoint offset;
+
+    protected int chunkArea;
+    protected int tileSize;
+
+    protected IndexedRenderer mesh;
+    protected Tile tile;
+
+
+    protected Block wall;
+
+    protected MapEditor editor;
+    protected IndexedRenderer[][] chunks;
+    protected Rectangle region;
+
+    protected RenderStrategy() {
+        windowPoint = new Point2();
+        gridPoint = new Point2();
+        chunkStartPoint = new Point2();
+        offset = new FloatPoint();
+        region = new Rectangle();
+
+        chunkArea = 0;
+        tileSize = tilesize;
+
+        mesh = null;
+        tile = null;
+        wall = null;
+
+        editor = null;
+        chunks = null;
+    }
+
+    protected static void preprocessing(RenderStrategy strategy, MapEditor editor,
+                                        IndexedRenderer[][] chunks,
+                                        int windowX, int windowY, int chunkSize) {
+        final int chunkStartX = (windowX % chunkSize);
+        final int chunkStartY = (windowY % chunkSize) * chunkSize;
+
+        strategy.setEditor(editor);
+        strategy.setChunks(chunks);
+
+        strategy.setGridPoint(windowX/chunkSize, windowY/chunkSize);
+        strategy.setWindowPoint(windowX, windowY);
+        strategy.setChunkStartPoint(chunkStartX, chunkStartY);
+        strategy.offset.setPoint(0, 0);
+        strategy.region.set(0, 0, 0, 0);
+
+        strategy.setChunkArea(chunkSize * chunkSize);
+
+        strategy.setTile(strategy.getWindowPoint());
+        strategy.setMesh(strategy.getGridPoint());
+
+        strategy.setWall(strategy.getTile().block());
+    }
+
+    public abstract void renderRegion();
+
+    protected void drawMesh(TextureRegion textureRegion, int index, boolean needsRotate) {
+        if(needsRotate){
+            final float rotationDegree = tile.rotation() * 90 - 90;
+            mesh.draw(index, textureRegion,
+                      region.x,
+                      region.y,
+                      region.width,
+                      region.height,
+                      rotationDegree);
+        }else{
+            mesh.draw(index, textureRegion,
+                      region.x,
+                      region.y,
+                      region.width,
+                      region.height);
+        }
+    }
+
+    protected int getRandomValue(int index, int length) {
+        return Mathf.randomSeed(index, 0, length - 1);
+    }
+
+    protected boolean getIsAirBlock(Block block) {
+        return block.equals(Blocks.air);
+    }
+
+    protected TextureAtlas.AtlasRegion getRegionInstance(String name) {
+        return Core.atlas.find(name);
+    }
+
+    protected float getMeshOffset(float size) {
+        return ((tilesize - size * Draw.scl) / 2f);
+    }
+
+    protected TextureRegion getEditorIcon(Block wall, boolean isEditorIconExist) {
+        return (isEditorIconExist ? wall.editorIcon() : getRegionInstance("clear-editor"));
+    }
+
+    public void setWindowPoint(int x, int y) {
+        this.windowPoint.set(x, y);
+    }
+
+    public Point2 getWindowPoint() {
+        return this.windowPoint;
+    }
+
+    public void setGridPoint(int x, int y) {
+        this.gridPoint.set(x, y);
+    }
+
+    public Point2 getGridPoint() {
+        return  this.gridPoint;
+    }
+
+    public void setChunkStartPoint(int x, int y) {
+        this.chunkStartPoint.set(x, y);
+    }
+
+    public Point2 getChunkStartPoint() {
+        return this.chunkStartPoint;
+    }
+
+    public void setChunkArea(int chunkArea) {
+        this.chunkArea = chunkArea;
+    }
+
+    public int getChunkArea() {
+        return this.chunkArea;
+    }
+
+    public void setTile(Point2 point) {
+        this.tile = editor.tiles()[point.x][point.y];
+    }
+
+    public Tile getTile() {
+        return this.tile;
+    }
+
+    public void setMesh(Point2 point) {
+        this.mesh = chunks[point.x][point.y];
+    }
+
+    public void setWall(Block wall) {
+        this.wall = wall;
+    }
+
+    public void setEditor(MapEditor editor) {
+        this.editor = editor;
+    }
+
+    public void setChunks(IndexedRenderer[][] chunks) {
+        this.chunks = chunks;
+    }
+
+    protected class FloatPoint{
+        private float x;
+        private float y;
+
+        public  FloatPoint() {
+
+        }
+
+        public void setPoint(float x, float y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        public float getX() {
+            return x;
+        }
+
+        public float getY() {
+            return y;
+        }
+
+        public void setX(float x) {
+            this.x = x;
+        }
+
+        public void setY(float y) {
+            this.y = y;
+        }
+    }
+}

--- a/core/src/io/anuke/mindustry/editor/TileStrategy.java
+++ b/core/src/io/anuke/mindustry/editor/TileStrategy.java
@@ -1,0 +1,102 @@
+package io.anuke.mindustry.editor;
+
+import io.anuke.arc.Core;
+import io.anuke.arc.graphics.Color;
+import io.anuke.arc.graphics.g2d.Draw;
+import io.anuke.arc.graphics.g2d.TextureRegion;
+import io.anuke.arc.math.Mathf;
+import io.anuke.arc.math.geom.Point2;
+import io.anuke.mindustry.game.Team;
+import io.anuke.mindustry.graphics.IndexedRenderer;
+
+public class TileStrategy extends RenderStrategy{
+    private static TileStrategy tileStrategy;
+
+    private int indexWall;
+    private int indexDecal;
+
+    private TileStrategy() {
+        super();
+        indexWall = 0;
+        indexDecal = 0;
+    }
+
+    public static TileStrategy getInstance(MapEditor editor, IndexedRenderer[][] chunks,
+                                                        int windowX, int windowY, int chunkSize){
+        if (tileStrategy == null) {
+            tileStrategy = new TileStrategy();
+        }
+        preprocessing(tileStrategy, editor, chunks, windowX, windowY, chunkSize);
+        Point2 chunkStart = tileStrategy.getChunkStartPoint();
+        final int indexWall = chunkStart.x + chunkStart.y;
+        final int indexDecal = chunkStart.x + chunkStart.y + tileStrategy.getChunkArea();
+        tileStrategy.setIndexWall(indexWall);
+        tileStrategy.setIndexDecal(indexDecal);
+        return tileStrategy;
+    }
+
+    private TextureRegion getSyntheticTexture() {
+        Team team = tile.getTeam();
+        mesh.setColor(team.color);
+        return getRegionInstance("block-border-editor");
+    }
+
+    private TextureRegion getNaturalTexture() {
+        final boolean isWallSynthetic = wall.synthetic();
+        final boolean isAirBlock = getIsAirBlock(wall);
+        final boolean isTileOverlay = tile.overlay() != null;
+        TextureRegion textureRegion;
+        if(!isWallSynthetic && !isAirBlock) {
+            textureRegion = getBlockTexture();
+            offset.setX(getMeshOffset(textureRegion.getWidth()));
+            offset.setY(getMeshOffset(textureRegion.getHeight()));
+        } else if (isAirBlock && isTileOverlay) {
+            textureRegion = getTileOverlayTexture();
+        } else {
+            textureRegion = getRegionInstance("clear-editor");
+        }
+
+        return textureRegion;
+    }
+
+    private TextureRegion getBlockTexture() {
+        final boolean isEditorIconExist = Core.atlas.isFound(wall.editorIcon());
+        return getEditorIcon(wall, isEditorIconExist);
+    }
+
+    private TextureRegion getTileOverlayTexture() {
+        final int editorVariantRegionLength = tile.overlay().editorVariantRegions().length;
+        final int randomValue = getRandomValue(indexWall, editorVariantRegionLength);
+        return tile.overlay().editorVariantRegions()[randomValue];
+    }
+
+    @Override
+    public void renderRegion() {
+        TextureRegion textureRegion;
+
+        final float offsetSize = -Mathf.floor((float)(wall.size / 3.0)) * tileSize;
+        offset.setPoint(offsetSize, offsetSize);
+
+        if (wall.update || wall.destructible) {
+            textureRegion = getSyntheticTexture();
+        } else {
+            textureRegion = getNaturalTexture();
+        }
+
+        region.setX(windowPoint.x * tileSize + offset.getX());
+        region.setY(windowPoint.y * tileSize + offset.getY());
+        region.setHeight(textureRegion.getWidth() * Draw.scl);
+        region.setWidth(textureRegion.getHeight() * Draw.scl);
+
+        drawMesh(textureRegion, indexDecal, false);
+        mesh.setColor(Color.WHITE);
+    }
+
+    public void setIndexWall(int indexWall) {
+        this.indexWall = indexWall;
+    }
+
+    public void setIndexDecal(int indexDecal) {
+        this.indexDecal = indexDecal;
+    }
+}


### PR DESCRIPTION
## Abstraction

Last time, I split the `render` which is in `MapRenderer.java` to `renderMeshRegion` and `renderTileRegion`.

However, it makes code size up to double of the original one. Furthermore, it causes to drop performance and compatibility. Because I make the instance every frame and use the `java.awt` library.

**First, I compress the code size to use the template method pattern.** Previous my commit, I saw that `render` method can split two methods(`renderMeshRegion` and `renderTileRegion`) and each has common logic. So, I apply the strategy pattern to reduce code size.

**Second,** some people say that creating an instance in the rendering is very dangerous. **I accept that idea and apply the each of rendering concrete class to singleton method.** As a result, it doesn't have any create instance situations.

**Third, I change all that feature related in `java.awt` to `io.anuke` library feature.** This makes more compatibility under the various platform

## Original

### MapRenderer.java

Method | CC
-- | --
FloatPoint.FloatPoint(float,float) | 1
MapRenderer(MapEditor) | 1
dispose() | 5
draw(float,float,float,float) | 5
drawMesh(IndexedRenderer,Tile,TextureRegion,int,Float,boolean) | 2
getChunkStartPoint(Point) | 1
getEditorIcon(Block,boolean) | 2
getMesh(Point) | 1
getMeshOffset(float) | 1
getRandomValue(int,int) | 1
getRegionInstance(String) | 1
getTile(Point) | 1
isAirBlock(Block) | 1
render(int,int) | 1
![#f03c15](https://placehold.it/15/f03c15/000000?text=+) renderMeshRegion(Point,IndexedRenderer,Tile,Block,int) | 5
![#f03c15](https://placehold.it/15/f03c15/000000?text=+) renderTileRegion(Point,IndexedRenderer,Tile,Block,int,int) | 7
resize(int,int) | 6
updateAll() | 3
updatePoint(int,int) | 1
**Average** | **2.42**

You can see too many method in one file. And you can still see a lot of code inside `render` method.

```java
private void render(int wx, int wy){
    final Point windowPoint = new Point(wx, wy);
    final Point gridPoint = new Point(wx/chunkSize, wy/chunkSize);

    final Point chunkStartPoint = getChunkStartPoint(windowPoint);
    final int chunkArea = chunkSize * chunkSize;


    IndexedRenderer mesh = getMesh(gridPoint);
    Tile tile = getTile(windowPoint);
    Block wall = tile.block();

    int indexWall = chunkStartPoint.x + chunkStartPoint.y;
    int indexDecal = chunkStartPoint.x  + chunkStartPoint.y + chunkArea;

    renderMeshRegion(windowPoint, mesh, tile, wall, indexWall);


    renderTileRegion(windowPoint, mesh, tile, wall, indexWall, indexDecal);
}
```

## Refactor

After I apply the strategy pattern. `render method` is changed like below.

```java
private void render(int wx, int wy){
    Render meshRendering = MeshRender.getInstance(editor, chunks, wx, wy, chunkSize);
    Render tileRendering = TileRender.getInstance(editor, chunks, wx, wy, chunkSize);
    meshRendering.renderRegion();
    tileRendering.renderRegion();
}
```

All the changes specifications like below.

### MapRenderer.java

Method | CC
-- | --
MapRenderer(MapEditor) | 1
dispose() | 5
draw(float,float,float,float) | 5
render(int,int) | 1
resize(int,int) | 6
updateAll() | 3
updatePoint(int,int) | 1
**Average** | **3.142857**

You can see the number of methods is reduced.

### Render.java


Method | CC
-- | --
FloatPoint.FloatPoint() | 1
FloatPoint.getX() | 1
FloatPoint.getY() | 1
FloatPoint.setPoint(float,float) | 1
FloatPoint.setX(float) | 1
FloatPoint.setY(float) | 1
Render() | 1
drawMesh(TextureRegion,int,boolean) | 2
getChunkArea() | 1
getChunkStartPoint() | 1
getEditorIcon(Block,boolean) | 2
getGridPoint() | 1
getIsAirBlock(Block) | 1
getMeshOffset(float) | 1
getRandomValue(int,int) | 1
getRegionInstance(String) | 1
getTile() | 1
getWindowPoint() | 1
preprocessing(Render,MapEditor,IndexedRenderer[][],int,int,int) | 1
setChunkArea(int) | 1
setChunkStartPoint(int,int) | 1
setChunks(IndexedRenderer[][]) | 1
setEditor(MapEditor) | 1
setGridPoint(int,int) | 1
setMesh(Point2) | 1
setTile(Point2) | 1
setWall(Block) | 1
setWindowPoint(int,int) | 1
**Average** | **1.071429**

### TileRender.java


Method | CC
-- | --
TileRender() | 1
getBlockTexture() | 1
getInstance(MapEditor,IndexedRenderer[][],int,int,int) | 2
getNaturalTexture() | 5
getSyntheticTexture() | 1
getTileOverlayTexture() | 1
renderRegion() | 3
setIndexDecal(int) | 1
setIndexWall(int) | 1
**Average** | **1.777778**

###  MeshRender.java

Method | CC
-- | --
MeshRender() | 1
getInstance(MapEditor,IndexedRenderer[][],int,int,int) | 2
renderRegion() | 5
setIndexWall(int) | 1
**Average** | **2.25**
